### PR TITLE
OpenShift compatability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,22 @@
-FROM alpine:3.7
+FROM nginx:stable-alpine
 
-# Install nginx and ffmpeg
+# Install ffmpeg and configure nginx
 RUN apk add --update nginx ffmpeg && rm -rf /var/cache/apk/* && mkdir /tmp/stream
 COPY nginx/nginx.conf /etc/nginx/nginx.conf
+
+# =================================================================================
+# Fix up permissions for OpenShift (non-root Docker user)
+# ref: https://torstenwalter.de/openshift/nginx/2017/08/04/nginx-on-openshift.html
+# - Make sure nginx can read and write it's working directories.
+# - The container dynamically configures nginx on startup
+# - The application artifacts live in /tmp
+# ---------------------------------------------------------------------------------
+RUN chmod g+rw /var/run \
+               /var/log/nginx \
+               /etc/nginx/nginx.conf \
+               /tmp \ 
+               /tmp/stream
+# =================================================================================
 
 COPY ./startup.sh /
 COPY ./create_ffmpeg_cmd.sh /

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,7 +1,8 @@
-user nginx;
+# user nginx; # Removed due to OpenShift running as non-root
 worker_processes  auto;
 
-error_log  /var/log/nginx/error.log warn;
+# error_log  /var/log/nginx/error.log warn;
+error_log  /var/log/nginx/error.log;
 pid        /var/run/nginx.pid;
 
 events {
@@ -16,8 +17,15 @@ http {
 
     access_log /var/log/nginx/access.log;
 
+    # Fix Filepath issues on OpenShift by forcing everything into /tmp
+    client_body_temp_path /tmp/nginx 1 2;
+    proxy_temp_path /tmp/nginx-proxy;
+    fastcgi_temp_path /tmp/nginx-fastcgi;
+    uwsgi_temp_path /tmp/nginx-uwsgi;
+    scgi_temp_path /tmp/nginx-scgi;
+
     server {
-        listen 80;
+        listen 8080;
 
         location / {
             # Disable cache


### PR DESCRIPTION
This pull request makes some minor tweaks to the Docker + Nginx configs in order to have it run on OpenShift.  Basically, that means that inside the Docker container the process has to run as non-root (as an added security measure). 

This should continue to work locally fine, but it's good to test it doesn't affect your flow.