### PR TITLE
added curl command to aid with healthchecks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM alpine:3.7
 
 # Install nginx and ffmpeg
 RUN apk add --update nginx ffmpeg && rm -rf /var/cache/apk/* && mkdir /tmp/stream
+RUN apk add curl
 COPY nginx/nginx.conf /etc/nginx/nginx.conf
 
 COPY ./startup.sh /


### PR DESCRIPTION
when running this using docker-compose, we could automatically do health check if there is a curl command available inside the container. 
```
  streamer:
    container_name: camera_streamer
    image: gihad/streamer
    restart: always
    environment:
      - PARAMETERS=xxx
    volumes:
      - /tmp/stream:/tmp/stream
    ports:
      - 8080:80
    healthcheck:
      test:
        [
          "CMD",
          "curl",
          "-f",
          "http://192.168.xxx.xxx:8080/mycamerafeed.m3u8"
        ]
      interval: 1m
      timeout: 10s
      retries: 3
```